### PR TITLE
Catch errors while adding success stat

### DIFF
--- a/lib/timberline/queue.rb
+++ b/lib/timberline/queue.rb
@@ -86,6 +86,8 @@ class Timberline
 
     def add_success_stat(item)
       add_stat_for_key(attr("success_stats"), item)
+    rescue Exception => e
+      $stderr.puts "Success Stat Error: #{e.inspect}, Item: #{item.inspect}"
     end
 
     private


### PR DESCRIPTION
We shouldn't be crashing the whole thing because the job succeeded but
an exception was thrown while reporting that success.

This will print the error to stderr instead. Probably not the best solution, so I'm totes open to other suggestions.
