### PR TITLE
Environment Variable Support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -95,6 +95,10 @@ queue (more on that later). There are 4 ways to configure Timberline:
 
 4. Running on Heroku? Define an environment variable for the URL:
 
+        export TIMBERLINE_URL="redis://:foobar@192.168.1.105:12345/1"
+
+   You can optionally use `REDIS_URL` instead:
+
         export REDIS_URL="redis://:foobar@192.168.1.105:12345/1"
 
    You can also specify the namespace via environment variables too:

--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ There are a few things that you probably want to be able to configure in
 Timberline. At the moment this is largely stuff related to the redis server
 connection, but you can also configure a namespace for your redis queues
 (defaults to "timberline") and a maximum number of retry attempts for jobs in the
-queue (more on that later). There are 3 ways to configure Timberline:
+queue (more on that later). There are 4 ways to configure Timberline:
 
 1. The most direct way is to configure Timberline via ruby code as follows:
 
@@ -70,7 +70,7 @@ queue (more on that later). There are 3 ways to configure Timberline:
           c.port = 12345
           c.password = "foobar"
         end
-   
+
    ...As long as you run this block before you attempt to access your queues,
    your settings will all take effect. Redis defaults will be used if you omit
    anything.
@@ -78,18 +78,28 @@ queue (more on that later). There are 3 ways to configure Timberline:
 2. If you're including Timberline in a Rails app, there's a convenient way to
    configure it that should fit in with the rest of your app - if you include a
    yaml file named timberline.yaml in your config directory, Timberline will
-   automatically detect it and load it up. The syntax for this file is
-   shockingly boring:
+   automatically detect it and load it up. Note that you will have to separate
+   each section by Rails environment, similar to your database.yml file. The
+   syntax for this file is shockingly boring:
 
-        database: 1
-        host: 192.168.1.105
-        port: 12345
-        password: foobar
+        development:
+          database: 1
+          host: 192.168.1.105
+          port: 12345
+          password: foobar
 
 3. Like the yaml format but you're not using Rails? Don't worry, just write your
    yaml file and set the TIMBERLINE\_YAML constant inside your app like so:
 
         TIMBERLINE_YAML = 'path/to/your/yaml/file.yaml'
+
+4. Running on Heroku? Define an environment variable for the URL:
+
+        export REDIS_URL="redis://:foobar@192.168.1.105:12345/1"
+
+   You can also specify the namespace via environment variables too:
+
+        export TIMBERLINE_NAMESPACE=awesome
 
 ### Pushing jobs onto a queue
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new do |t|
-  t.libs << "test"
-  t.test_files = FileList['test/unit/test_*.rb']
+  t.pattern = "test/unit/*_test.rb"
   t.verbose = true
 end

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -1,6 +1,6 @@
 class Timberline
   class Config
-    attr_accessor :database, :host, :port, :timeout, :password, :logger, :namespace, :max_retries, :stat_timeout
+    attr_accessor :url, :database, :host, :port, :timeout, :password, :logger, :namespace, :max_retries, :stat_timeout
 
     def initialize
       if defined? TIMBERLINE_YAML
@@ -20,6 +20,7 @@ class Timberline
       end
 
       # load defaults
+      @url = timberline_env_vars
       @namespace  ||= 'timberline'
       @max_retries ||= 5
       @stat_timeout ||= 60
@@ -28,7 +29,7 @@ class Timberline
     def redis_config
       config = {}
 
-      { :db => database, :host => host, :port => port, :timeout => timeout, :password => password, :logger => logger }.each do |name, value|
+      { :url => url, :db => database, :host => host, :port => port, :timeout => timeout, :password => password, :logger => logger }.each do |name, value|
         config[name] = value unless value.nil?
       end
 
@@ -40,6 +41,12 @@ class Timberline
       ["database","host","port","timeout","password","logger","namespace"].each do |setting|
         self.instance_variable_set("@#{setting}", yaml_config[setting])
       end
+    end
+
+    private
+
+    def timberline_env_vars
+      ENV['TIMBERLINE_URL'] || ENV['REDIS_URL']
     end
   end
 end

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -20,8 +20,8 @@ class Timberline
       end
 
       # load defaults
-      @url = timberline_env_vars
-      @namespace  ||= 'timberline'
+      @url = timberline_env_url
+      @namespace  ||= ENV['TIMBERLINE_NAMESPACE'] || 'timberline'
       @max_retries ||= 5
       @stat_timeout ||= 60
     end
@@ -45,7 +45,7 @@ class Timberline
 
     private
 
-    def timberline_env_vars
+    def timberline_env_url
       ENV['TIMBERLINE_URL'] || ENV['REDIS_URL']
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,6 @@
 require 'minitest/autorun'
 require 'ostruct'
 
-require 'nutrasuite'
-
 # include the gem
 require 'timberline'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'ostruct'
 
 require 'nutrasuite'

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
-class ConfigTest < Test::Unit::TestCase
-  a "Config object without any preset YAML configs" do
+describe Timberline::Config do
+  describe "without any preset YAML configs" do
     before do
       @config = Timberline::Config.new
     end
@@ -42,7 +42,7 @@ class ConfigTest < Test::Unit::TestCase
     end
   end
 
-  a "Config object in a Rails app without a config file" do
+  describe "in a Rails app without a config file" do
     before do
       Object::Rails = OpenStruct.new(:root => File.join(File.dirname(File.path(__FILE__)), "..", "gibberish"), :env => "development")
       @config = Timberline::Config.new
@@ -64,7 +64,7 @@ class ConfigTest < Test::Unit::TestCase
     end
   end
 
-  a "Config object in a Rails app with a config file" do
+  describe "in a Rails app with a config file" do
     before do
       Object::Rails = OpenStruct.new(:root => File.join(File.dirname(File.path(__FILE__)), "..", "fake_rails"), :env => "development")
       @config = Timberline::Config.new
@@ -84,7 +84,7 @@ class ConfigTest < Test::Unit::TestCase
     end
   end
 
-  a "Config object when TIMBERLIBE_YAML is defined" do
+  describe "when TIMBERLINE_YAML is defined" do
     before do
       Object::TIMBERLINE_YAML = File.join(File.dirname(File.path(__FILE__)), "..", "test_config.yaml")
       ENV['TIMBERLINE_URL'] = 'redis://:foo@localhost:12345/3'
@@ -97,7 +97,7 @@ class ConfigTest < Test::Unit::TestCase
     end
 
     it "loads the specified yaml file" do
-      assert_equal "redis://localhost:12345", @config.url
+      assert_equal "redis://:foo@localhost:12345/3", @config.url
       assert_equal "localhost", @config.host
       assert_equal 12345, @config.port
       assert_equal 10, @config.timeout
@@ -107,7 +107,7 @@ class ConfigTest < Test::Unit::TestCase
     end
   end
 
-  a "Config object when TIMBERLINE_YAML is defined" do
+  describe "when TIMBERLINE_YAML is defined" do
     before do
       Object::TIMBERLINE_YAML = File.join(File.dirname(File.path(__FILE__)), "..", "test_config.yaml")
       @config = Timberline::Config.new
@@ -127,7 +127,7 @@ class ConfigTest < Test::Unit::TestCase
     end
   end
 
-  a "Config object when TIMBERLINE_YAML is defined, but doesn't exist" do
+  describe "when TIMBERLINE_YAML is defined, but doesn't exist" do
     before do
       Object::TIMBERLINE_YAML = File.join(File.dirname(File.path(__FILE__)), "..", "fake_config.yaml")
     end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -87,7 +87,7 @@ class ConfigTest < Test::Unit::TestCase
   a "Config object when TIMBERLIBE_YAML is defined" do
     before do
       Object::TIMBERLINE_YAML = File.join(File.dirname(File.path(__FILE__)), "..", "test_config.yaml")
-      ENV['TIMBERLINE_URL'] = 'redis://bar:foo@localhost:12345/3'
+      ENV['TIMBERLINE_URL'] = 'redis://:foo@localhost:12345/3'
       @config = Timberline::Config.new
     end
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -84,6 +84,28 @@ class ConfigTest < Test::Unit::TestCase
     end
   end
 
+  a "Config object when TIMBERLIBE_YAML is defined" do
+    before do
+      Object::TIMBERLINE_YAML = File.join(File.dirname(File.path(__FILE__)), "..", "test_config.yaml")
+      ENV['TIMBERLINE_URL'] = 'redis://bar:foo@localhost:12345/3'
+      @config = Timberline::Config.new
+    end
+
+    after do
+      Object.send(:remove_const, :TIMBERLINE_YAML)
+    end
+
+    it "loads the specified yaml file" do
+      assert_equal "redis://localhost:12345", @config.url
+      assert_equal "localhost", @config.host
+      assert_equal 12345, @config.port
+      assert_equal 10, @config.timeout
+      assert_equal "foo", @config.password
+      assert_equal 3, @config.database
+      assert_equal "treecurve", @config.namespace
+    end
+  end
+
   a "Config object when TIMBERLINE_YAML is defined" do
     before do
       Object::TIMBERLINE_YAML = File.join(File.dirname(File.path(__FILE__)), "..", "test_config.yaml")

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ConfigTest < Test::Unit::TestCase
   a "Config object without any preset YAML configs" do

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -93,6 +93,7 @@ class ConfigTest < Test::Unit::TestCase
 
     after do
       Object.send(:remove_const, :TIMBERLINE_YAML)
+      ENV['TIMBERLINE_URL'] = nil
     end
 
     it "loads the specified yaml file" do

--- a/test/unit/envelope_test.rb
+++ b/test/unit/envelope_test.rb
@@ -1,9 +1,8 @@
 require_relative '../test_helper'
 require 'date'
 
-class EnvelopeTest < Test::Unit::TestCase
-
-  a "newly instantiated Envelope object" do
+describe Timberline::Envelope do
+  describe "newly instantiated" do
     before do
       @envelope = Timberline::Envelope.new
     end
@@ -29,7 +28,7 @@ class EnvelopeTest < Test::Unit::TestCase
     end
   end
 
-  an "Envelope object with contents" do
+  describe "with contents" do
     before do
       @envelope = Timberline::Envelope.new
       @envelope.contents = "Test data"

--- a/test/unit/envelope_test.rb
+++ b/test/unit/envelope_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 require 'date'
 
 class EnvelopeTest < Test::Unit::TestCase

--- a/test/unit/queue_test.rb
+++ b/test/unit/queue_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
-class QueueTest < Test::Unit::TestCase
-  a "newly instantiated Queue" do
+describe Timberline::Queue do
+  describe "newly instantiated" do
     before do
       clear_test_db
       @queue = Timberline::Queue.new("test_queue")
@@ -88,7 +88,7 @@ class QueueTest < Test::Unit::TestCase
 
   end
 
-  a "Queue with one item" do
+  describe "with one item" do
     before do
       clear_test_db
       @test_item = "Test Queue Item"

--- a/test/unit/queue_test.rb
+++ b/test/unit/queue_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class QueueTest < Test::Unit::TestCase
   a "newly instantiated Queue" do

--- a/test/unit/timberline_test.rb
+++ b/test/unit/timberline_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
-class TimberlineTest < Test::Unit::TestCase
-  a "Freshly set up Timberline" do
+describe Timberline do
+  describe "Freshly set up" do
     before do
       reset_timberline
     end

--- a/test/unit/timberline_test.rb
+++ b/test/unit/timberline_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class TimberlineTest < Test::Unit::TestCase
   a "Freshly set up Timberline" do


### PR DESCRIPTION
This is a Pull Request to add in Redis URL support via Environment Variable to make it behave similarly to Sidekiq and Resque. It'll also enable Timberline to work on services like Heroku where you are provided an environment variable for connections.

Do note, this PR upgrades the test suite to Mini-test as I was unable to determine the Ruby version for the project and could not get the suite working under Ruby 2.0. The suite is passing via `rake test` on Ruby 2.0.0-p353.

Left to-do:

- [x] Get test suite working correctly around new env var
- [x] Document new ENV var option
- [x] Allow namespace configuration via ENV