### PR TITLE
Fix error in anon worker

### DIFF
--- a/lib/timberline/anonymous_worker.rb
+++ b/lib/timberline/anonymous_worker.rb
@@ -10,7 +10,7 @@ class Timberline
     # and error_item so that the block can easily control the processing
     # flow for queued items.
     #
-    # @param [Block] block the block to run against each item that gets popped 
+    # @param [Block] block the block to run against each item that gets popped
     #   off the queue.
     #
     # @example Creating a simple AnonymousWorker

--- a/lib/timberline/anonymous_worker.rb
+++ b/lib/timberline/anonymous_worker.rb
@@ -34,11 +34,13 @@ class Timberline
       binding = @block.binding
       binding.eval <<-HERE
         def retry_item(item)
-          Worker.retry_item(item)
+          Timberline.retry_item(item)
+          raise Timberline::ItemRetried
         end
 
         def error_item(item)
-          Worker.error_item(item)
+          Timberline.error_item(item)
+          raise Timberline::ItemErrored
         end
       HERE
     end

--- a/lib/timberline/worker.rb
+++ b/lib/timberline/worker.rb
@@ -35,7 +35,7 @@ class Timberline
 
     # Given an item off of the queue, process it appropriately.
     # Not implemented in Worker, as Worker is just a base class.
-    # 
+    #
     def process_item(item)
       raise NotImplementedError
     end

--- a/spec/lib/timberline/anonymous_worker_spec.rb
+++ b/spec/lib/timberline/anonymous_worker_spec.rb
@@ -18,4 +18,22 @@ describe Timberline::AnonymousWorker do
       expect(queue.error_queue.length).to eq(1)
     end
   end
+
+  describe "worker is passed to block" do
+    it "doesn't raise a error when #error_item is called" do
+      queue = Timberline::Queue.new("foo_queue")
+      queue.push("apple")
+
+      expect do
+        Timberline.watch("foo_queue") do |job, worker|
+          begin
+            worker.error_item(job)
+          rescue Timberline::ItemErrored
+            break
+          end
+        end
+      end.to_not raise_error
+      expect(queue.error_queue.length).to eq(1)
+    end
+  end
 end

--- a/spec/lib/timberline/anonymous_worker_spec.rb
+++ b/spec/lib/timberline/anonymous_worker_spec.rb
@@ -7,8 +7,15 @@ describe Timberline::AnonymousWorker do
       queue.push("apple")
 
       expect do
-        Timberline.watch("foo_queue") {|job| error_item(job) }
+        Timberline.watch("foo_queue") do |job|
+          begin
+            error_item(job)
+          rescue Timberline::ItemErrored
+            break
+          end
+        end
       end.to_not raise_error
+      expect(queue.error_queue.length).to eq(1)
     end
   end
 end

--- a/spec/lib/timberline/anonymous_worker_spec.rb
+++ b/spec/lib/timberline/anonymous_worker_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Timberline::AnonymousWorker do
+  describe "error_item works in block" do
+    it "doesn't raise a error when #error_item is called" do
+      queue = Timberline::Queue.new("foo_queue")
+      queue.push("apple")
+
+      expect do
+        Timberline.watch("foo_queue") {|job| error_item(job) }
+      end.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/timberline/queue_spec.rb
+++ b/spec/lib/timberline/queue_spec.rb
@@ -34,7 +34,7 @@ describe Timberline::Queue do
     subject { Timberline::Queue.new("fritters") }
 
     before do
-      subject.delete 
+      subject.delete
     end
 
     it "removes the queue from redis" do


### PR DESCRIPTION
This fixes Anonymous workers that try to retry or error jobs.  This was broken back in [this commit](https://github.com/treehouse/timberline/commit/b031b589d28867e03d373214df995ba403dc0041).

I tried a few other ways to inject a reference to the instance of anonymous workers to the block, but ruby wasn't playing with me.

I think we should depreciate these methods.  If workers want to do what these methods do they should do something like:

```ruby
Timberline.watch queue do |job, worker|
  worker.error_item(job)
end
```

