### PR TITLE
Add support for passing "sentinels" option on to the redis connection

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -180,14 +180,14 @@ the [timberline-rails](https://github.com/treehouse/timberline-rails) gem.
 The Redis client (>= v3.2) is able to [perform automatic Redis
 connection](https://github.com/redis/redis-rb#sentinel-support) failovers by
 using [Redis Sentinel](http://redis.io/topics/sentinel). In cases where this is
-enabled, pass sentinal configuration on to the Redis client using the
-"sentinals" key a configuration:
+enabled, pass sentinel configuration on to the Redis client using the
+"sentinels" key a configuration:
 
 Via timberline.yml:
 
 ```yaml
 host: 127.0.0.1
-sentinals:
+sentinels:
   - host: 127.0.0.1
     port: 26379
 ```
@@ -197,7 +197,7 @@ Via the Timberline.configure:
 ```ruby
 Timberline.configure do |c|
   # ...
-  c.sentinals = [{ host: 127.0.0.1, port: 26379 }]
+  c.sentinels = [{ host: 127.0.0.1, port: 26379 }]
 end
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -83,7 +83,7 @@ queue (more on that later). There are 3 ways to configure Timberline:
           c.port = 12345
           c.password = "foobar"
         end
-   
+
    ...As long as you run this block before you attempt to access your queues,
    your settings will all take effect. Redis defaults will be used if you omit
    anything.
@@ -151,7 +151,7 @@ you could write a queue processor that reads off of that queue.
 ### Using the binary
 
 In order to make reading off of the queue easier, there's a binary named
-`Timberline` included with this gem. 
+`Timberline` included with this gem.
 
 Example:
 
@@ -168,12 +168,38 @@ block until either the process is killed, or until something is added to the
 queue.
 
 There are some options to the Timberline binary that you may find helpful -
-`timberline --help` for more. 
+`timberline --help` for more.
 
 ### Rails
 
 If you're using Timberline in conjunction with a Rails environment, check out
 the [timberline-rails](https://github.com/treehouse/timberline-rails) gem.
+
+### Redis Failover
+
+The Redis client (>= v3.2) is able to [perform automatic Redis
+connection](https://github.com/redis/redis-rb#sentinel-support) failovers by
+using [Redis Sentinel](http://redis.io/topics/sentinel). In cases where this is
+enabled, pass sentinal configuration on to the Redis client using the
+"sentinals" key a configuration:
+
+Via timberline.yml:
+
+```yaml
+host: 127.0.0.1
+sentinals:
+  - host: 127.0.0.1
+    port: 26379
+```
+
+Via the Timberline.configure:
+
+```ruby
+Timberline.configure do |c|
+  # ...
+  c.sentinals = [{ host: 127.0.0.1, port: 26379 }]
+end
+```
 
 ## TODO
 

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -3,9 +3,9 @@ class Timberline
   # as well as Timberline-specific configuration values, like how many times an
   # item should be retried in a queue.
   #
-  # @attr [Integer] database part of the redis configuration - index of the 
+  # @attr [Integer] database part of the redis configuration - index of the
   #   redis database to use
-  # @attr [String] host part of the redis configuration - the hostname of the 
+  # @attr [String] host part of the redis configuration - the hostname of the
   #   redis server
   # @attr [Integer] port part of the redis configuration - the port of the
   #   redis server
@@ -21,14 +21,16 @@ class Timberline
   #   should be allowed to retry itself before it is placed on the error queue
   # @attr [Integer] stat_timeout the number of minutes that stats will stay live
   #   in redis before they are expired
+  # @attr [Array] sentinals a list of Sentinal hosts that can be connected to
+  #   for failover protection.
   #
   class Config
-    attr_accessor :database, :host, :port, :timeout, :password, 
-                  :logger, :namespace, :max_retries, :stat_timeout
+    attr_accessor :database, :host, :port, :timeout, :password,
+                  :logger, :namespace, :max_retries, :stat_timeout, :sentinals
 
     # Attemps to load configuration from TIMBERLINE_YAML, if it exists.
     # Otherwise creates a default Config object.
-    def initialize 
+    def initialize
       if defined? TIMBERLINE_YAML
         if File.exists?(TIMBERLINE_YAML)
           yaml = YAML.load_file(TIMBERLINE_YAML)
@@ -49,7 +51,7 @@ class Timberline
       @max_retries ||= 5
     end
 
-    # @return [Integer] the configured lifetime of stats (in minutes), with a default of 60 
+    # @return [Integer] the configured lifetime of stats (in minutes), with a default of 60
     def stat_timeout
       @stat_timeout ||= 60
     end
@@ -58,7 +60,15 @@ class Timberline
     def redis_config
       config = {}
 
-      { db: database, host: host, port: port, timeout: timeout, password: password, logger: logger }.each do |name, value|
+      {
+        db: database,
+        host: host,
+        port: port,
+        timeout: timeout,
+        password: password,
+        logger: logger,
+        sentinals: sentinals
+      }.each do |name, value|
         config[name] = value unless value.nil?
       end
 
@@ -68,7 +78,7 @@ class Timberline
   private
     def load_from_yaml(yaml_config)
       raise "Missing yaml configs!" if yaml_config.nil?
-      ["database","host","port","timeout","password","logger","namespace"].each do |setting|
+      %w(database host port timeout password logger namespace sentinals).each do |setting|
         self.instance_variable_set("@#{setting}", yaml_config[setting])
       end
     end

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -21,12 +21,12 @@ class Timberline
   #   should be allowed to retry itself before it is placed on the error queue
   # @attr [Integer] stat_timeout the number of minutes that stats will stay live
   #   in redis before they are expired
-  # @attr [Array] sentinals a list of Sentinal hosts that can be connected to
+  # @attr [Array] sentinels a list of sentinel hosts that can be connected to
   #   for failover protection.
   #
   class Config
     attr_accessor :database, :host, :port, :timeout, :password,
-                  :logger, :namespace, :max_retries, :stat_timeout, :sentinals
+                  :logger, :namespace, :max_retries, :stat_timeout, :sentinels
 
     # Attemps to load configuration from TIMBERLINE_YAML, if it exists.
     # Otherwise creates a default Config object.
@@ -67,7 +67,7 @@ class Timberline
         timeout: timeout,
         password: password,
         logger: logger,
-        sentinals: sentinals
+        sentinels: sentinels
       }.each do |name, value|
         config[name] = value unless value.nil?
       end
@@ -78,7 +78,7 @@ class Timberline
   private
     def load_from_yaml(yaml_config)
       raise "Missing yaml configs!" if yaml_config.nil?
-      %w(database host port timeout password logger namespace sentinals).each do |setting|
+      %w(database host port timeout password logger namespace sentinels).each do |setting|
         self.instance_variable_set("@#{setting}", yaml_config[setting])
       end
     end

--- a/spec/config/test_config.yaml
+++ b/spec/config/test_config.yaml
@@ -4,3 +4,7 @@ timeout: 10
 password: foo
 database: 3
 namespace: treecurve
+sentinals:
+  -
+    host: localhost
+    port: 111111

--- a/spec/config/test_config.yaml
+++ b/spec/config/test_config.yaml
@@ -4,7 +4,7 @@ timeout: 10
 password: foo
 database: 3
 namespace: treecurve
-sentinals:
+sentinels:
   -
     host: localhost
     port: 111111

--- a/spec/lib/timberline/config_spec.rb
+++ b/spec/lib/timberline/config_spec.rb
@@ -35,6 +35,11 @@ describe Timberline::Config do
         it "loads the namespace from the config file" do
           expect(subject.namespace).to eq("treecurve")
         end
+
+        it "loads the sentinals from the config file" do
+          sentinals = [{"host" => "localhost", "port" => 111111}]
+          expect(subject.sentinals).to eq sentinals
+        end
       end
 
       context "and the specified file doesn't exist" do

--- a/spec/lib/timberline/config_spec.rb
+++ b/spec/lib/timberline/config_spec.rb
@@ -36,9 +36,9 @@ describe Timberline::Config do
           expect(subject.namespace).to eq("treecurve")
         end
 
-        it "loads the sentinals from the config file" do
-          sentinals = [{"host" => "localhost", "port" => 111111}]
-          expect(subject.sentinals).to eq sentinals
+        it "loads the sentinels from the config file" do
+          sentinels = [{"host" => "localhost", "port" => 111111}]
+          expect(subject.sentinels).to eq sentinels
         end
       end
 


### PR DESCRIPTION
The Redis client will automatically listen for failover events from Sentinal. This adds the ability to configure the Timberline Redis connection with Sentinal connection values. 

https://github.com/treehouse/issues/issues/1198

