### PR TITLE
Only store incremental statistics about jobs instead of all items.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
+0.8.6
+  - Store cumulative statistics instead of full items in each state
+  - Removes stat_timeout config variable
 0.8.4
-  - Allow stat_timeout and max_retries to be set from config 
+  - Allow stat_timeout and max_retries to be set from config
 0.8.3
   - Add support for configuring via env var
   - Add support for Redis sentinels

--- a/lib/timberline.rb
+++ b/lib/timberline.rb
@@ -4,7 +4,6 @@ require 'yaml'
 
 require 'redis'
 require 'redis-namespace'
-require 'redis-expiring-set/monkeypatch'
 
 require_relative "timberline/version"
 require_relative "timberline/exceptions"

--- a/lib/timberline.rb
+++ b/lib/timberline.rb
@@ -126,20 +126,6 @@ class Timberline
     @config.max_retries
   end
 
-  # Lazy-loads the Timberline configuration.
-  # @return [Integer] the stat_timeout expressed in minutes
-  def self.stat_timeout
-    initialize_if_necessary
-    @config.stat_timeout
-  end
-
-  # Lazy-loads the Timberline configuration.
-  # @return [Integer] the stat_timeout expressed in seconds
-  def self.stat_timeout_seconds
-    initialize_if_necessary
-    @config.stat_timeout * 60
-  end
-
   # Create and start a new AnonymousWorker with the given
   # queue_name and block. Convenience method.
   #

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -21,14 +21,12 @@ class Timberline
   #   will create and manage
   # @attr [Integer] max_retries the number of times that an item on the queue
   #   should be allowed to retry itself before it is placed on the error queue
-  # @attr [Integer] stat_timeout the number of minutes that stats will stay live
-  #   in redis before they are expired
   # @attr [Array] sentinels a list of sentinel hosts that can be connected to
   #   for failover protection.
   #
   class Config
     attr_accessor :database, :host, :port, :timeout, :password,
-                  :logger, :namespace, :max_retries, :stat_timeout, :sentinels
+                  :logger, :namespace, :max_retries, :sentinels
 
     # Attemps to load configuration from TIMBERLINE_YAML, if it exists.
     # Otherwise creates a default Config object.
@@ -45,11 +43,6 @@ class Timberline
     # @return [Integer] the configured maximum number of retries, with a default of 5
     def max_retries
       @max_retries ||= 5
-    end
-
-    # @return [Integer] the configured lifetime of stats (in minutes), with a default of 60
-    def stat_timeout
-      @stat_timeout ||= 60
     end
 
     # @return [{host: "x", port: 1}] list of sentinel server
@@ -105,7 +98,7 @@ class Timberline
       @password = uri.password
 
       params = uri.query.nil? ? {} : CGI.parse(uri.query)
-      %w(timeout namespace stat_timeout max_retries).each do |setting|
+      %w(timeout namespace max_retries).each do |setting|
         next unless params.key?(setting)
         instance_variable_set("@#{setting}", convert_if_int(params[setting][0]))
       end
@@ -119,7 +112,7 @@ class Timberline
 
     def load_from_yaml(yaml_config)
       fail "Missing yaml configs!" if yaml_config.nil?
-      %w(database host port timeout password namespace sentinels stat_timeout max_retries).each do |setting|
+      %w(database host port timeout password namespace sentinels max_retries).each do |setting|
         instance_variable_set("@#{setting}", yaml_config[setting])
       end
     end

--- a/lib/timberline/queue.rb
+++ b/lib/timberline/queue.rb
@@ -82,7 +82,7 @@ class Timberline
     #
     # @param [#to_json, Timberline::Envelope] contents either contents that can
     #   be converted to JSON and stuffed in an Envelope, or an Envelope itself
-    #   that needs to be put on the queue.  
+    #   that needs to be put on the queue.
     # @param [Hash] metadata metadata that will be attached to the envelope for
     # contents.
     #
@@ -168,6 +168,7 @@ class Timberline
     #   [stat_timeout] minutes.
     #
     def average_execution_time
+      return nil if number_successes == 0
       total_run_duration / number_successes
     end
 
@@ -233,6 +234,15 @@ class Timberline
     # @return [Integer] the current total runtime in seconds.
     def increment_run_time_by(num)
       Timberline.redis.incrby( attr("total_run_duration"), num )
+    end
+
+    # Resets statistics of the queue
+    #
+    def reset_statistics!
+      Timberline.redis.set( attr("retry_count"), 0 )
+      Timberline.redis.set( attr("error_count"), 0 )
+      Timberline.redis.set( attr("success_count"), 0 )
+      Timberline.redis.set( attr("total_run_duration"), 0 )
     end
 
     # @return [Timberline::Queue] a (hidden) Queue object where this queue's

--- a/lib/timberline/queue.rb
+++ b/lib/timberline/queue.rb
@@ -125,8 +125,7 @@ class Timberline
       "#{@queue_name}:#{key}"
     end
 
-    # The number of items that have encountered fatal errors on the queue
-    # during the last [stat_timeout] minutes.
+    # The number of items that have encountered fatal errors on the queue.
     #
     # @return [Integer]
     #
@@ -135,8 +134,7 @@ class Timberline
       result.to_i
     end
 
-    # The number of items that have been retried on the queue
-    # during the last [stat_timeout] minutes.
+    # The number of items that have been retried on the queue.
     #
     # @return [Integer]
     #
@@ -145,8 +143,7 @@ class Timberline
       result.to_i
     end
 
-    # The number of items that were processed successfully for this queue
-    # during the last [stat_timeout] minutes.
+    # The number of items that were processed successfully for this queue.
     #
     # @return [Integer]
     #
@@ -160,12 +157,10 @@ class Timberline
       result.to_i
     end
 
-    # Given all of the successful jobs that were executed in the last
-    # [stat_timeout] minutes, determine how long on average those jobs
+    # Given all of the successful jobs that were executed, determine how long on average those jobs
     # took to execute.
     #
-    # @return [Float] the average execution time for successful jobs in the last
-    #   [stat_timeout] minutes.
+    # @return [Float] the average execution time for successful jobs.
     #
     def average_execution_time
       return nil if number_successes == 0

--- a/lib/timberline/queue.rb
+++ b/lib/timberline/queue.rb
@@ -131,7 +131,8 @@ class Timberline
     # @return [Integer]
     #
     def number_errors
-      Timberline.redis.xcard attr("error_stats")
+      result = Timberline.redis.get(attr("error_count")) || 0
+      result.to_i
     end
 
     # The number of items that have been retried on the queue
@@ -140,7 +141,8 @@ class Timberline
     # @return [Integer]
     #
     def number_retries
-      Timberline.redis.xcard attr("retry_stats")
+      result = Timberline.redis.get(attr("retry_count")) || 0
+      result.to_i
     end
 
     # The number of items that were processed successfully for this queue
@@ -149,7 +151,13 @@ class Timberline
     # @return [Integer]
     #
     def number_successes
-      Timberline.redis.xcard attr("success_stats")
+      result = Timberline.redis.get(attr("success_count")) || 0
+      result.to_i
+    end
+
+    def total_run_duration
+      result = Timberline.redis.get(attr("total_run_duration")) || 0
+      result.to_i
     end
 
     # Given all of the successful jobs that were executed in the last
@@ -160,22 +168,7 @@ class Timberline
     #   [stat_timeout] minutes.
     #
     def average_execution_time
-      successes = Timberline.redis.xmembers(attr("success_stats")).map { |item| Envelope.from_json(item)}
-      times = successes.map do |item|
-        if item.finished_processing_at
-          item.finished_processing_at.to_f - item.started_processing_at.to_f
-        elsif item.fatal_error_at
-          item.fatal_error_at.to_f - item.started_processing_at.to_f
-        else
-          nil
-        end
-      end
-      times.reject! { |t| t.nil? }
-      if times.size == 0
-        0
-      else
-        times.inject(0, :+) / times.size.to_f
-      end
+      total_run_duration / number_successes
     end
 
     # Given an item that needs to be retried, increment the retry count,
@@ -191,7 +184,7 @@ class Timberline
       if (item.retries < Timberline.max_retries)
         item.retries += 1
         item.last_tried_at = Time.now.to_f
-        add_retry_stat(item)
+        increment_retry_stat
         push(item)
       else
         error_item(item)
@@ -205,38 +198,41 @@ class Timberline
     #
     def error_item(item)
       item.fatal_error_at = Time.now.to_f
-      add_error_stat(item)
+      increment_error_stat
       self.error_queue.push(item)
     end
 
-    # Stores an item from the queue that was retried so we can keep track
-    # of things like how many retries have been attempted on this queue, etc.
+    # Increments the queue's retried job count.
     #
-    # @param [Envelope] item an item that fatally errored on this queue
+    # @return [Integer] the count after incrementation has occured
     #
-    def add_retry_stat(item)
-      add_stat_for_key(attr("retry_stats"), item)
+    def increment_retry_stat
+      Timberline.redis.incr attr("retry_count")
     end
 
-    # Stores an item from the queue that fatally errored so we can keep track
-    # of things like how many errors have occurred on this queue, etc.
+    # Increments the queue's errored job count.
     #
-    # @param [Envelope] item an item that fatally errored on this queue
+    # @return [Integer] the count after incrementation has occured
     #
-    def add_error_stat(item)
-      add_stat_for_key(attr("error_stats"), item)
+    def increment_error_stat
+      Timberline.redis.incr attr("error_count")
     end
 
-    # Stores a successfully processed queue item as a statistic so we can keep
-    # track of things like average execution time, number of successes, etc.
+    # Increments the queue's successfully processed job count.
     #
-    # @param [Envelope] item an item that was processed successfully for this
-    #   queue
+    # @return [Integer] the count after incrementation has occured
     #
-    def add_success_stat(item)
-      add_stat_for_key(attr("success_stats"), item)
-    rescue Exception => e
-      $stderr.puts "Success Stat Error: #{e.inspect}, Item: #{item.inspect}"
+    def increment_success_stat
+      Timberline.redis.incr attr("success_count")
+    end
+
+    # Increments the queue's total runtime by [num]
+    #
+    # @params [Integer] number of seconds to increment the runtime by.
+    #
+    # @return [Integer] the current total runtime in seconds.
+    def increment_run_time_by(num)
+      Timberline.redis.incrby( attr("total_run_duration"), num )
     end
 
     # @return [Timberline::Queue] a (hidden) Queue object where this queue's
@@ -246,11 +242,8 @@ class Timberline
       @error_queue ||= Timberline.queue(attr("errors"), hidden: true)
     end
 
-    private
 
-    def add_stat_for_key(key, item)
-      Timberline.redis.xadd key, item, Time.now + Timberline.stat_timeout_seconds
-    end
+    private
 
     def next_id
       Timberline.redis.incr attr("id_seq")

--- a/lib/timberline/version.rb
+++ b/lib/timberline/version.rb
@@ -1,4 +1,4 @@
 class Timberline
   # The current canonical version for Timberline.
-  VERSION = "0.8.5"
+  VERSION = "0.8.6"
 end

--- a/lib/timberline/worker.rb
+++ b/lib/timberline/worker.rb
@@ -31,7 +31,9 @@ class Timberline
           end
 
           item.finished_processing_at = Time.now.to_f
-          @queue.add_success_stat(item)
+          run_time = item.finished_processing_at - item.started_processing_at
+          @queue.increment_run_time_by(run_time)
+          @queue.increment_success_stat
         rescue ItemRetried, ItemErrored
           next
         ensure

--- a/spec/config/test_config.yaml
+++ b/spec/config/test_config.yaml
@@ -5,7 +5,6 @@ password: foo
 database: 3
 namespace: treecurve
 max_retries: 1212
-stat_timeout: 1313
 sentinels:
   -
     host: localhost

--- a/spec/lib/timberline/config_spec.rb
+++ b/spec/lib/timberline/config_spec.rb
@@ -4,7 +4,7 @@ describe Timberline::Config do
   describe "newly created" do
     context "when the TIMBERLINE_URL env var is defined" do
       before do
-        ENV["TIMBERLINE_URL"] = "redis://:apassword@ahostname:9000/3?timeout=666&namespace=foobar&sentinel=sentinel1:1&sentinel=sentinel2:2&max_retries=99&stat_timeout=12"
+        ENV["TIMBERLINE_URL"] = "redis://:apassword@ahostname:9000/3?timeout=666&namespace=foobar&sentinel=sentinel1:1&sentinel=sentinel2:2&max_retries=99"
       end
 
       after do
@@ -33,10 +33,6 @@ describe Timberline::Config do
 
       it "loads the namespace from the env var" do
         expect(subject.namespace).to eq("foobar")
-      end
-
-      it "loads the stat_timeout from the env var" do
-        expect(subject.stat_timeout).to eq(12)
       end
 
       it "loads the max_retries from the env var" do
@@ -81,10 +77,6 @@ describe Timberline::Config do
           expect(subject.max_retries).to eq(1212)
         end
 
-        it "loads the stat_timeout from the config file" do
-          expect(subject.stat_timeout).to eq(1313)
-        end
-
         it "loads the database from the config file" do
           expect(subject.database).to eq(3)
         end
@@ -121,10 +113,6 @@ describe Timberline::Config do
 
       it "configures a default max_retries of 5" do
         expect(subject.max_retries).to eq(5)
-      end
-
-      it "configures a stat_timeout of 60" do
-        expect(subject.stat_timeout).to eq(60)
       end
 
       it "doesn't configure any redis settings so that redis will use its own defaults" do

--- a/spec/lib/timberline/queue_spec.rb
+++ b/spec/lib/timberline/queue_spec.rb
@@ -75,7 +75,7 @@ describe Timberline::Queue do
       subject.push("Test")
       expect(subject.length).to eq(1)
     end
-    
+
     it "properly formats data so it can be popped successfully" do
       subject.push("Test")
       expect(subject.pop).to be_a Timberline::Envelope
@@ -179,6 +179,41 @@ describe Timberline::Queue do
         expect(subject).to receive(:error_item).with(item)
         subject.retry_item(item)
       end
+    end
+  end
+
+  describe "#reset_statistics!" do
+    subject { Timberline::Queue.new("donuts") }
+
+    before do
+      subject.increment_error_stat
+      subject.increment_retry_stat
+      subject.increment_success_stat
+      subject.increment_run_time_by(10)
+    end
+
+    it "resets error_count" do
+      expect(subject.number_errors).to eq(1)
+      subject.reset_statistics!
+      expect(subject.number_errors).to eq(0)
+    end
+
+    it "resets retry_count" do
+      expect(subject.number_retries).to eq(1)
+      subject.reset_statistics!
+      expect(subject.number_retries).to eq(0)
+    end
+
+    it "resets success_count" do
+      expect(subject.number_successes).to eq(1)
+      subject.reset_statistics!
+      expect(subject.number_successes).to eq(0)
+    end
+
+    it "resets total_run_duration" do
+      expect(subject.average_execution_time).to eq(10)
+      subject.reset_statistics!
+      expect(subject.average_execution_time).to be_nil
     end
   end
 end

--- a/spec/lib/timberline/queue_spec.rb
+++ b/spec/lib/timberline/queue_spec.rb
@@ -182,6 +182,27 @@ describe Timberline::Queue do
     end
   end
 
+  describe "#average_execution_time" do
+    subject { Timberline::Queue.new("tacos") }
+    context "when no jobs have completed" do
+      it "returns nil" do
+        expect(subject.average_execution_time).to be_nil
+      end
+    end
+
+    context "when jobs have completed" do
+      before do
+        subject.increment_success_stat
+        subject.increment_success_stat
+        subject.increment_run_time_by(100)
+      end
+
+      it "returns the average run time" do
+        expect(subject.average_execution_time).to eq(50)
+      end
+    end
+  end
+
   describe "#reset_statistics!" do
     subject { Timberline::Queue.new("donuts") }
 

--- a/spec/lib/timberline_spec.rb
+++ b/spec/lib/timberline_spec.rb
@@ -272,48 +272,4 @@ describe Timberline do
       end
     end
   end
-
-  describe ".stat_timeout" do
-    context "if Timberline hasn't been configured yet" do
-      before { Timberline.stat_timeout }
-
-      it "initializes a new configuration object" do
-        expect(Timberline.config).not_to be_nil
-      end
-    end
-
-    context "if Timberline has been configured" do
-      before do
-        Timberline.configure do |c|
-          c.stat_timeout = 10
-        end
-      end
-
-      it "returns the configured number of minutes for stat timeout" do
-        expect(Timberline.stat_timeout).to eq(10)
-      end
-    end
-  end
-
-  describe ".stat_timeout_seconds" do
-    context "if Timberline hasn't been configured yet" do
-      before { Timberline.stat_timeout_seconds }
-
-      it "initializes a new configuration object" do
-        expect(Timberline.config).not_to be_nil
-      end
-    end
-
-    context "if Timberline has been configured" do
-      before do
-        Timberline.configure do |c|
-          c.stat_timeout = 10
-        end
-      end
-
-      it "returns the configured number of seconds for stat timeout" do
-        expect(Timberline.stat_timeout_seconds).to eq(600)
-      end
-    end
-  end
 end

--- a/spec/lib/timberline_spec.rb
+++ b/spec/lib/timberline_spec.rb
@@ -278,7 +278,7 @@ describe Timberline do
       before { Timberline.stat_timeout }
 
       it "initializes a new configuration object" do
-        expect(Timberline.config).not_to be_nil  
+        expect(Timberline.config).not_to be_nil
       end
     end
 
@@ -300,7 +300,7 @@ describe Timberline do
       before { Timberline.stat_timeout_seconds }
 
       it "initializes a new configuration object" do
-        expect(Timberline.config).not_to be_nil  
+        expect(Timberline.config).not_to be_nil
       end
     end
 

--- a/timberline.gemspec
+++ b/timberline.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "redis"
   s.add_runtime_dependency "redis-namespace"
-  s.add_runtime_dependency "redis-expiring-set"
   s.add_runtime_dependency "trollop"
   s.add_runtime_dependency "daemons"
 


### PR DESCRIPTION
Statistics in timberline have been building up really fast for larger queues and requiring infrastructure to empty them rather quickly. This PR switches over to simply storing a summary of stats that can be emptied at will via an external source (e.g. a scheduled task). This also removes the dependency on expiring set.
