### PR TITLE
Delayed Envelope Opening

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+UNRELEASED
+  - Allow queueing jobs for later execution
 0.8.4
   - Allow stat_timeout and max_retries to be set from config 
 0.8.3

--- a/README.markdown
+++ b/README.markdown
@@ -24,7 +24,9 @@ kind of issues you might be dealing with:
 
 ## Documentation
 
-Documentation for Timberline is available on rubydoc.info [here](http://rubydoc.info/github/treehouse/timberline/frames). The code itself is documented with YARD.
+Documentation for Timberline is available on rubydoc.info
+[here](http://rubydoc.info/github/treehouse/timberline/frames). The code itself
+is documented with YARD.
 
 ## Concepts
 
@@ -105,16 +107,28 @@ queue (more on that later). There are 3 ways to configure Timberline:
 
 ### Pushing jobs onto a queue
 
-To push a job onto the queue you'll want to make use of the `Timberline#push`
+To push a job onto the queue you'll want to make use of the `Timberline.push`
 method, like so:
 
     Timberline.push "queue_name", data, { other_data: some_stuff }
 
-`queue_name` is the name of the queue you want to push data onto; data is the
+`queue_name` is the name of the queue you want to push data onto; `data` is the
 data you want to push onto the queue (remember that this all gets converted to
 JSON, so you probably want to stick to things that represent well as strings),
 and the optional third argument is a hash of any extra parameters you want to
 include in the job's envelope.
+
+### Pushing jobs onto a queue for execution at a latter day/month/century
+
+To push a job onto the queue to be run at a latter time, provide a `run_at`
+attribute as part of third argument to `Timberline.push`. For example, if you
+wanted to run a job 5 minutes from now, you might do something like this:
+
+    Timeberline.push "queue_name", data, { run_at: DateTime.now + 300 }
+
+*Caveat*: There are no guarantees the job will run exactly at the time provided,
+just that it will be executed by the watcher some time after the provided `run_at`
+time.
 
 ### Reading from a queue
 

--- a/lib/timberline/envelope.rb
+++ b/lib/timberline/envelope.rb
@@ -45,6 +45,17 @@ class Timberline
       JSON.unparse(build_envelope_hash)
     end
 
+    # Determines if an envelope should be operated on later than
+    # right now.
+    #
+    # @return [Boolean]
+    def open_later?
+      return false unless run_at
+
+      open_time = DateTime.parse(run_at)
+      DateTime.now < open_time
+    end
+
     # Passes any missing methods on to the metadata hash to provide better access.
     # @example Easily read from metadata
     #   some_envelope.origin_queue # returns metadata["origin_queue"]

--- a/lib/timberline/worker.rb
+++ b/lib/timberline/worker.rb
@@ -20,6 +20,10 @@ class Timberline
 
       while(keep_watching?)
         item = @queue.pop
+        if item.open_later?
+          @queue.push(item)
+          next
+        end
         @executing_job = true
         item.started_processing_at = Time.now.to_f
 

--- a/spec/lib/timberline/config_spec.rb
+++ b/spec/lib/timberline/config_spec.rb
@@ -109,7 +109,7 @@ describe Timberline::Config do
         end
 
         it "raises an exception to let you know the file doesn't exist" do
-          expect { Timberline::Config.new }.to raise_error
+          expect { Timberline::Config.new }.to raise_error(StandardError)
         end
       end
     end

--- a/spec/lib/timberline/envelope_spec.rb
+++ b/spec/lib/timberline/envelope_spec.rb
@@ -88,4 +88,34 @@ describe Timberline::Envelope do
       expect(envelope.fritters).to eq "the bacon kind"
     end
   end
+
+  describe "#operate_later?" do
+    let(:base_data_hash) { { contents: "test content" }}
+    let(:json_string) { JSON.unparse(data_hash) }
+    let(:envelope) { Timberline::Envelope.from_json(json_string) }
+
+    context "job without run_at set" do
+      let(:data_hash) { base_data_hash }
+
+      it "can operate on the envelope now" do
+        expect(envelope.open_later?).to eq(false)
+      end
+    end
+
+    context "future job with run_at set" do
+      let(:data_hash) { base_data_hash.merge(run_at: DateTime.now + 300) } # 5min from now
+
+      it "can operate on the envelope later" do
+        expect(envelope.open_later?).to eq(true)
+      end
+    end
+
+    context "old job with run_at set" do
+      let(:data_hash) { base_data_hash.merge(run_at: DateTime.now - 1) } # 1s ago
+
+      it "can operate on the envelope now" do
+        expect(envelope.open_later?).to eq(false)
+      end
+    end
+  end
 end

--- a/timberline.gemspec
+++ b/timberline.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "yard"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", '~> 3.0.0.rc1'
+  s.add_development_dependency "rspec"
   s.add_development_dependency "pry"
 end


### PR DESCRIPTION
## Why

Was chatting with @aimee-ault about ActiveJob integration and lack of support for enqueuing jobs for later execution. So this is a first stab because I was curious.

## What

* Bump RSpec to latest (this is easy to cherry pick)
* Added a dequeue-enqueue step before job execution in the worker loop

## Additional

[This bit](https://github.com/treehouse/timberline-rails/blob/master/lib/active_job/queue_adapters/timberline_adapter.rb#L12) in the active job adapter is going to have to change. Probably to something like:

```ruby
def enqueue_at(job, timestamp)
  Timberline.push job.queue_name, job.serialize, run_at: timestamp
end
```

## Caveats

I haven't ever run timberline, so this might be a terrible approach. Certainly it might cause a lot of redis churn. The mechanism by which the jobs are re-enqueued is not going to be handled by the various error catchers below the definition, so maybe there needs to be another layer there, or the code needs to be refactored to do the dequeueing inside a rescue block.