### PR TITLE
Mute job result logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
-  # - 1.9.3
+  - 2.2.0
+  - 2.5.0
   - jruby-19mode
   - jruby-head
-  - 2.0.0
-  - 2.1.0
   - ruby-head
 services: 
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
+  # - 1.9.3
   - jruby-19mode
   - jruby-head
   - 2.0.0

--- a/lib/timberline.rb
+++ b/lib/timberline.rb
@@ -141,6 +141,13 @@ class Timberline
     @config.stat_timeout * 60
   end
 
+  # Lazy-loads the Timberline configuration.
+  # @return [Boolean] whether we want to record result stats for each job in a redis queue
+  def self.log_job_results?
+    initialize_if_necessary
+    @config.log_job_result_stats
+  end
+
   # Create and start a new AnonymousWorker with the given
   # queue_name and block. Convenience method.
   #

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -99,6 +99,11 @@ class Timberline
       val.match(/\A[+-]?\d+\Z/) ? val.to_i : val
     end
 
+    def convert_if_bool(val)
+      # convert potential string respresentations of boolean values to ruby booleans
+      val.to_s.strip.downcase == "true"
+    end
+
     def configure_via_env
       return unless ENV.key?("TIMBERLINE_URL")
 
@@ -111,7 +116,11 @@ class Timberline
       @password = uri.password
 
       params = uri.query.nil? ? {} : CGI.parse(uri.query)
-      %w(timeout namespace stat_timeout max_retries log_job_result_stats).each do |setting|
+      %w(log_job_result_stats).each do |setting|
+        next unless params.key?(setting)
+        instance_variable_set("@#{setting}", convert_if_bool(params[setting][0]))
+      end
+      %w(timeout namespace stat_timeout max_retries).each do |setting|
         next unless params.key?(setting)
         instance_variable_set("@#{setting}", convert_if_int(params[setting][0]))
       end

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -54,7 +54,7 @@ class Timberline
 
     # @return [Boolean] configuration setting for logging each job success or error in redis
     # created in response to max memory limit on redis queues in aws
-    def log_job_result?
+    def log_job_result_stats
       @log_job_result_stats ||= false
     end
 
@@ -111,7 +111,7 @@ class Timberline
       @password = uri.password
 
       params = uri.query.nil? ? {} : CGI.parse(uri.query)
-      %w(timeout namespace stat_timeout max_retries).each do |setting|
+      %w(timeout namespace stat_timeout max_retries log_job_result_stats).each do |setting|
         next unless params.key?(setting)
         instance_variable_set("@#{setting}", convert_if_int(params[setting][0]))
       end
@@ -125,7 +125,7 @@ class Timberline
 
     def load_from_yaml(yaml_config)
       fail "Missing yaml configs!" if yaml_config.nil?
-      %w(database host port timeout password namespace sentinels stat_timeout max_retries).each do |setting|
+      %w(database host port timeout password namespace sentinels stat_timeout max_retries log_job_result_stats).each do |setting|
         instance_variable_set("@#{setting}", yaml_config[setting])
       end
     end

--- a/lib/timberline/config.rb
+++ b/lib/timberline/config.rb
@@ -27,7 +27,7 @@ class Timberline
   #   for failover protection.
   #
   class Config
-    attr_accessor :database, :host, :port, :timeout, :password,
+    attr_accessor :database, :host, :port, :timeout, :password, :log_job_result_stats,
                   :logger, :namespace, :max_retries, :stat_timeout, :sentinels
 
     # Attemps to load configuration from TIMBERLINE_YAML, if it exists.
@@ -50,6 +50,12 @@ class Timberline
     # @return [Integer] the configured lifetime of stats (in minutes), with a default of 60
     def stat_timeout
       @stat_timeout ||= 60
+    end
+
+    # @return [Boolean] configuration setting for logging each job success or error in redis
+    # created in response to max memory limit on redis queues in aws
+    def log_job_result?
+      @log_job_result_stats ||= false
     end
 
     # @return [{host: "x", port: 1}] list of sentinel server

--- a/lib/timberline/queue.rb
+++ b/lib/timberline/queue.rb
@@ -99,21 +99,21 @@ class Timberline
     # @see Timberline::Queue#pop
     #
     def pause
-      @redis[attr("paused")] = "true"
+      @redis.set(attr("paused"), "true")
     end
 
     # Takes this queue back out of paused mode.
     # @see Timberline::Queue#pop
     #
     def unpause
-      @redis[attr("paused")] = "false"
+      @redis.set(attr("paused"), "false")
     end
 
     # Indicates whether or not this queue is currently in paused mode.
     # @return [boolean]
     #
     def paused?
-      @redis[attr("paused")] == "true"
+      @redis.get(attr("paused")) == "true"
     end
 
     # Given a key, create a string namespaced to this queue name.

--- a/lib/timberline/queue.rb
+++ b/lib/timberline/queue.rb
@@ -249,6 +249,7 @@ class Timberline
     private
 
     def add_stat_for_key(key, item)
+      return unless Timberline.log_job_results?
       Timberline.redis.xadd key, item, Time.now + Timberline.stat_timeout_seconds
     end
 

--- a/spec/lib/timberline/queue_spec.rb
+++ b/spec/lib/timberline/queue_spec.rb
@@ -190,4 +190,64 @@ describe Timberline::Queue do
       end
     end
   end
+
+  describe "#add_--_stat" do
+
+    context "error stat logging" do
+      
+      subject    { Timberline::Queue.new("popovers") }
+      let(:item) { subject.push("butter"); subject.pop }
+
+      it "doesn't log an error if log_job_result_stats is set to false (default setting)" do
+        subject.add_error_stat(item)
+        expect(subject.number_errors).to eq(0)
+      end
+
+      it "logs an error if log_job_result_stats is set to true" do
+        Timberline.configure do |c|
+          c.log_job_result_stats = true
+        end
+        subject.add_error_stat(item)
+        expect(subject.number_errors).to eq(1)
+      end
+    end
+
+    context "success stat logging" do
+      
+      subject    { Timberline::Queue.new("dutch_oven") }
+      let(:item) { subject.push("strawberry_jam"); subject.pop }
+
+      it "doesn't log a success if log_job_result_stats is set to false (default setting)" do
+        subject.add_success_stat(item)
+        expect(subject.number_successes).to eq(0)
+      end
+
+      it "logs a success if log_job_result_stats is set to true" do
+        Timberline.configure do |c|
+          c.log_job_result_stats = true
+        end
+        subject.add_success_stat(item)
+        expect(subject.number_successes).to eq(1)
+      end
+    end
+
+    context "retry stat logging" do
+      
+      subject    { Timberline::Queue.new("pancakes") }
+      let(:item) { subject.push("blueberry"); subject.pop }
+
+      it "doesn't log a retry attempt if log_job_result_stats is set to false (default setting)" do
+        subject.add_retry_stat(item)
+        expect(subject.number_retries).to eq(0)
+      end
+
+      it "logs a retry attempt if log_job_result_stats is set to true" do
+        Timberline.configure do |c|
+          c.log_job_result_stats = true
+        end
+        subject.add_retry_stat(item)
+        expect(subject.number_retries).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/lib/timberline/queue_spec.rb
+++ b/spec/lib/timberline/queue_spec.rb
@@ -38,11 +38,11 @@ describe Timberline::Queue do
     end
 
     it "removes the queue from redis" do
-      expect(Timberline.redis["fritters"]).to be_nil 
+      expect(Timberline.redis.get("fritters")).to be_nil
     end
 
     it "removes all of the queue's attributes from redis" do
-      expect(Timberline.redis["fritters:*"]).to be_nil
+      expect(Timberline.redis.get("fritters:*")).to be_nil
     end
 
     it "removes the queue from the Timberline queue listing" do
@@ -113,6 +113,9 @@ describe Timberline::Queue do
     let(:item) { subject.push("apple"); subject.pop }
 
     before do
+      Timberline.configure do |c|
+        c.log_job_result_stats = true
+      end
       subject.error_item(item)
     end
 
@@ -135,6 +138,9 @@ describe Timberline::Queue do
 
     context "when the item hasn't been retried before" do
       before do
+        Timberline.configure do |c|
+          c.log_job_result_stats = true
+        end
         subject.retry_item(item)
       end
 
@@ -153,6 +159,9 @@ describe Timberline::Queue do
 
     context "when the item has been retried before" do
       before do
+        Timberline.configure do |c|
+          c.log_job_result_stats = true
+        end
         item.retries = 3
         subject.retry_item(item)
       end

--- a/timberline.gemspec
+++ b/timberline.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "yard"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", '~> 3.0.0.rc1'
+  s.add_development_dependency "rspec", '~> 3.5'
   s.add_development_dependency "pry"
 end


### PR DESCRIPTION
Infrastructure ran into a problem on our aws hosting where the redis queues has hit their storage limits. This was in large part to job logging by our Timberline library, and the job logs had grown to 10 tens the size of the actual job storage in little more than a month. On IBM hosting, a script had been written to clear these logs periodically, but after consulting with infrastructure, it seemed that we had no real need for these logs in the first place.

This PR is to add a configuration option to mute the logs in timberline related to each job's success, error, and retry status. This `log_job_result_stats` key in the timberline configuration will default to false, thus automatically turning logging off in all current uses of Timberline. Setting `log_job_result_stats` to true in the Timberline configuration manually will allow Timberline to continue to log this information for those few queues that we need such information for.

In doing this work, I also came across 28 tests that were no longer passing do to a change in the redis-rb api, so I also updated the methods related to queue pausing to use current redis api commands.